### PR TITLE
Bug fixes when deployed as standalone server

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -5,7 +5,7 @@ const fu = require('../utils/file')
 
 const getList = async (req, res) => {
   try {
-    const host = `${req.protocol}://${req.headers.origin || req.headers.host}`
+    const host = `${req.protocol}://${req.headers.host || req.headers.origin}`
     const { skip, limit } = req.body
     const { count, documents } = await service.listFiles(host, skip, limit)
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const fileUpload = require('express-fileupload')
 const router = require('./router')
 
 const REQUEST_LIMIT = '10mb'
-const PORT = 8888
+const PORT = process.env.PORT || 8888
 
 const start = async () => {
   http.listen(PORT, () =>

--- a/services/index.js
+++ b/services/index.js
@@ -46,7 +46,7 @@ const listFiles = async (host, skip, limit) => {
 
   return {
     documents,
-    count: files.length
+    count: documents.length
   }
 }
 


### PR DESCRIPTION
 - image url should use the host not origin
- dynamic port value in-case platform has specific value e.g. heroku
 - use documents length as count instead of files